### PR TITLE
fix(grammar): less strict preceding whitespace requirements for define

### DIFF
--- a/client/src/syntaxes/openfga.tmLanguage.json
+++ b/client/src/syntaxes/openfga.tmLanguage.json
@@ -79,7 +79,7 @@
 	  "symbols": {
 		"patterns": [
 			{
-			  "match": "^\\s{4}(define)\\s+([a-zA-Z0-9-_]+)\\s+(as)\\s+",
+			  "match": "\\b(define)\\s+([a-zA-Z0-9-_]+)\\s+(as)\\s+",
 			  "captures": {
 					"1": { "name": "keyword.define.openfga" },
 					"2": { "name": "entity.name.function.member.relation.name.openfga" },
@@ -87,7 +87,7 @@
 			   }
 			},
 			{
-			  "match": "^\\s{4}(define)\\s+([a-zA-Z0-9-_]+)\\s*(:)\\s*(\\[\\s*([a-zA-Z0-9-_:#*]|,\\s*)+\\s*])?",
+			  "match": "\\b(define)\\s+([a-zA-Z0-9-_]+)\\s*(:)\\s*(\\[\\s*([a-zA-Z0-9-_:#*]|,\\s*)+\\s*])?",
 			  "captures": {
 					"1": { "name": "keyword.define.openfga" },
 					"2": { "name": "entity.name.function.member.relation.name.openfga" },


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Corrected regex for `define` token to remove requirement of 4 whitespace chars at beginning

## Description
<!-- Provide a detailed description of the changes -->

- Closes https://github.com/openfga/vscode-ext/issues/14

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
