### PR TITLE
fix: change focus to new json file on transform

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,6 @@ module.exports = {
 		'@typescript-eslint/no-explicit-any': 0,
 		'@typescript-eslint/explicit-module-boundary-types': 0,
 		'@typescript-eslint/no-non-null-assertion': 0,
+		'no-trailing-spaces': ["error", { "skipBlankLines": false }]
 	}
 };

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -15,15 +15,15 @@ export function activate(context: ExtensionContext) {
 			return;
 		}
 		const text = activeEditor.document.getText();
-		
+
 		const modelInApiFormat = friendlySyntaxToApiSyntax(text);
 
 		const doc = await workspace.openTextDocument({
-			content: JSON.stringify(modelInApiFormat, null, "  "), 
+			content: JSON.stringify(modelInApiFormat, null, "  "),
 			language: "json"
 		});
 
-		return (await window.showTextDocument(doc)).document
+		return (await window.showTextDocument(doc)).document;
 	});
 
 	context.subscriptions.push(transformCommand);

--- a/client/src/test/extension.test.ts
+++ b/client/src/test/extension.test.ts
@@ -1,6 +1,6 @@
 
 import { join } from 'path';
-import * as fs from 'fs'
+import * as fs from 'fs';
 import assert = require('assert');
 import { activate } from '../extension';
 import { ExtensionContext, TextDocument, commands, window, workspace } from 'vscode';
@@ -30,31 +30,31 @@ suite('Should execute command', () => {
 			logPath: '',
 			extensionMode: undefined,
 			extension: undefined
-		}
+		};
 
 		// Attempt to activate context
 		activate(context);
-		
+
 		// Assert command assigned assigned for disposal
-		assert.equal(context.subscriptions.length, 1)
+		assert.equal(context.subscriptions.length, 1);
 
 		const docUri = getDocUri('test.fga');
-		
+
 		// Get editor window
 		const editor = await window.showTextDocument(docUri);
 
 		// Get result from running command against what is in editor window
-		const resultFromCommand = await commands.executeCommand<TextDocument>('openfga.commands.transformToJson')
+		const resultFromCommand = await commands.executeCommand<TextDocument>('openfga.commands.transformToJson');
 
 		// Get original document
 		const original = fs.readFileSync(getDocUri('test.fga').fsPath);
 
 		// Call transform directly for comparison, using original doc
-		const resultFromMethodCall = JSON.stringify(friendlySyntaxToApiSyntax(original.toString()), null, "  ")
+		const resultFromMethodCall = JSON.stringify(friendlySyntaxToApiSyntax(original.toString()), null, "  ");
 
 		// Ensure result from command is the same as result from method.
-		assert.equal(editor.document.getText(), original)
-		assert.equal(resultFromCommand.getText(), resultFromMethodCall)
+		assert.equal(editor.document.getText(), original);
+		assert.equal(resultFromCommand.getText(), resultFromMethodCall);
 	});
 
 });


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Added command to focus on newly generated text file, when created.

## Description
<!-- Provide a detailed description of the changes -->

Modified command to use `window.showTextDocument()` to open focus only the newly created file.

[openfga-vscode-1.0.0.vsix.zip](https://github.com/openfga/vscode-ext/files/12196667/openfga-vscode-1.0.0.vsix.zip)

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- Closes https://github.com/openfga/vscode-ext/issues/22

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
