### PR TITLE
chore: Seperate dryrun and real publish workflows

### DIFF
--- a/.github/workflows/dryrun-publish.yaml
+++ b/.github/workflows/dryrun-publish.yaml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
 
-name: Publish Extension
+name: Dryrun Publish Extension
 jobs:
   dryrun-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/dryrun-publish.yaml
+++ b/.github/workflows/dryrun-publish.yaml
@@ -1,12 +1,9 @@
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - "*"
 
 name: Publish Extension
 jobs:
-  publish:
+  dryrun-publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -26,6 +23,6 @@ jobs:
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@dfe4f6ad46624424fe24cb5bca79839183399045 # 1.4.0
         with:
-          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          pat: "this_is_a_stub"
           registryUrl: https://marketplace.visualstudio.com/
-
+          dryRun: true


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

* Splitting dryrun and real release workflows
* Dryrun only manually invoked now via `workflow_dispatch`

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
