### PR TITLE
fix(ci): Using correct activate for test suite

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,6 +48,7 @@ jobs:
         cache: 'npm'
         cache-dependency-path: ./package-lock.json
     - run: npm install
+    - run: npm run webpack
     - run: npm run compile
     - run: xvfb-run -a npm test
       if: runner.os == 'Linux'

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To generate an installable build of this extension, you can do the following:
 ### Testing
 
 - Run `npm install` in the root directory. This installs all necessary npm modules.
+- Run `npm run webpack` to bundle the code
 - Run `npm run compile` to compile the code & client for testing.
 - Run `npm test` to execute the client test suite.
 

--- a/client/src/test/extension.test.ts
+++ b/client/src/test/extension.test.ts
@@ -1,44 +1,19 @@
 
-import { join } from 'path';
+
 import * as fs from 'fs';
 import assert = require('assert');
-import { activate } from '../extension';
-import { ExtensionContext, TextDocument, commands, window, workspace } from 'vscode';
-import { getDocUri } from './helper';
+import { TextDocument, commands, window } from 'vscode';
+import { getDocUri, activate } from './helper';
 import { friendlySyntaxToApiSyntax } from '@openfga/syntax-transformer';
 
 
 suite('Should execute command', () => {
 
+	const docUri = getDocUri('test.fga');
+
 	test('Generates expected JSON', async () => {
-		const context: ExtensionContext = {
-			subscriptions: [],
-			workspaceState: undefined,
-			globalState: undefined,
-			secrets: undefined,
-			extensionUri: undefined,
-			extensionPath: '',
-			environmentVariableCollection: undefined,
-			asAbsolutePath: function (relativePath: string): string {
-				throw new Error('Function not implemented.');
-			},
-			storageUri: undefined,
-			storagePath: '',
-			globalStorageUri: undefined,
-			globalStoragePath: '',
-			logUri: undefined,
-			logPath: '',
-			extensionMode: undefined,
-			extension: undefined
-		};
 
-		// Attempt to activate context
-		activate(context);
-
-		// Assert command assigned assigned for disposal
-		assert.equal(context.subscriptions.length, 1);
-
-		const docUri = getDocUri('test.fga');
+		await activate(docUri);
 
 		// Get editor window
 		const editor = await window.showTextDocument(docUri);


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

* Was using the wrong `activate()` for tests. Changed to use correct helper method. 

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- Closes https://github.com/openfga/vscode-ext/issues/15

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
