### PR TITLE
fix: reduce to working language-configuration set

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,145 +1,37 @@
 {
-  "language": {
-    "defaultToken": "",
-    "tokenPostfix": ".openfga",
-    "keywords": [],
-    "operators": [],
-    "identifiers": {},
-    "comments": {
-      "lineComment": "#",
+  "comments": {
+    "lineComment": "#",
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+  ],
+  "indentationRules": {
+   
+  },
+  "onEnterRules": [
+    {
+      "beforeText": "^model$",
+      "action": { "indent": "indent" }
     },
-    "brackets": [
-      ["{", "}"],
-      ["[", "]"],
-      ["(", ")"]
-    ],
-    "autoClosingPairs": [
-      { "open": "{", "close": "}" },
-      { "open": "[", "close": "]" },
-      { "open": "(", "close": ")" },
-    ],
-    "surroundingPairs": [
-      ["{", "}"],
-      ["[", "]"],
-      ["(", ")"],
-    ],
-    "indentationRules": {
-      "indentNextLinePattern": "^model$",
-      "increaseIndentPattern": "^((type\\s+.*+)|(\\s{2}relations)|(\\s{4}define.*?))$",
-      "decreaseIndentPattern": "^\\s{2}schema 1\\.[01]$"
+    {
+      "beforeText": "^\\s*relations$",
+      "action": { "indent": "indent" }
     },
-
-    "onEnterRules": [
-      {
-        "beforeText": "^\\s*(?:type|relations|model|define).*?:\\s*$",
-        "action": { "indent": "indent" },
-      },
-      {
-        "beforeText": "^\\s{2}schema 1\\.[01]$",
-        "action": { "indent": "outdent" },
-      }
-    ],
-    "tokenizer": {
-      "root": [
-        { "include": "@whitespace" },
-        [{}, "comment"],
-        [
-          {},
-          [
-            "@brackets",
-            "@whitespace",
-            "type.type-restrictions.value",
-            "@whitespace",
-            "@brackets"
-          ]
-        ],
-        [
-          {},
-          [
-            "comma.type-restrictions.delimiter",
-            "@whitespace",
-            "type.type-restrictions.value",
-            "@whitespace",
-            "@brackets"
-          ]
-        ],
-        [
-          {},
-          [
-            "@brackets",
-            "@whitespace",
-            "type.type-restrictions.value",
-            "@whitespace",
-            "comma.type-restrictions.delimiter"
-          ]
-        ],
-        [{}, "@brackets"],
-        [{}, ["schema.keyword", "@whitespace", "schema.value"]],
-        [{}, ["type.keyword", "@whitespace", "name.type.value"]],
-        [{}, ["define.keyword", "@whitespace", "name.relation.value"]],
-        [{}, ["union.operator", "@whitespace", "computed.relation.value"]],
-        [
-          {},
-          ["intersection.operator", "@whitespace", "computed.relation.value"]
-        ],
-        [{}, ["exclusion.operator", "@whitespace", "computed.relation.value"]],
-        [{}, ["as.keyword", "@whitespace", "computed.relation.value"]],
-        [
-          {},
-          ["colon.define.delimiter", "@whitespace", "computed.relation.value"]
-        ],
-        [
-          {},
-          [
-            "computed.tupletouserset.relation.value",
-            "@whitespace",
-            "from.keyword",
-            "@whitespace",
-            "tupleset.tupletouserset.relation.value"
-          ]
-        ],
-        [
-          {},
-          [
-            "type.type-restrictions.value",
-            "hashtag.type-restrictions.delimiter",
-            "relation.type-restrictions.value"
-          ]
-        ],
-        [
-          {},
-          [
-            "type.type-restrictions.value",
-            "colon.type-restrictions.delimiter",
-            "wildcard.type-restrictions.value"
-          ]
-        ],
-        [":", "colon.define.delimiter"],
-        [",", "comma.type-restrictions.delimiter"],
-        ["but not", "exclusion.operator"],
-        ["self", "self.keyword"],
-        [
-          {},
-          {
-            "cases": {
-              "and": "intersection.operator",
-              "or": "union.operator",
-              "type": "type.keyword",
-              "relations": "relations.keyword",
-              "define": "define.keyword",
-              "from": "from.keyword",
-              "as": "as.keyword",
-              "model": "model.keyword",
-              "schema": { "token": "schema.keyword" },
-              "@default": "tupleset.tupletouserset.relation.value"
-            }
-          }
-        ]
-      ],
-      "whitespace": [
-        [{}, "white"],
-        [{}, "comment"]
-      ]
+    {
+      "beforeText": "^\\s{2}schema 1\\.[01]$",
+      "action": { "indent": "outdent" },
     }
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,12 @@
 				"configuration": "./language-configuration.json"
 			}
 		],
+		"snippets": [
+			{
+				"language": "openfga",
+				"path": "./snippets.json"
+			}
+		],
 		"grammars": [
 			{
 				"language": "openfga",

--- a/snippets.json
+++ b/snippets.json
@@ -1,0 +1,28 @@
+{
+	"model": {
+		"prefix": "model",
+		"body": [
+			"model",
+			"  schema 1.$0"
+		]
+	},
+	"type": {
+		"prefix": "type",
+		"body": [
+			"type $0"
+		]
+	},
+	"relations": {
+		"prefix": "relations",
+		"body": [
+			"relations",
+			"\tdefine $1: $0"
+		]
+	},
+	"define": {
+		"prefix": "define",
+		"body": [
+			"define $1: $0"
+		]
+	}
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

* Removed code that was not being used by language-configuration
* Added onEnter rules for text based indentation
* Tested manually for what felt expected when writting

Open to expanding further with more developer experience needed

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- Closes https://github.com/openfga/vscode-ext/issues/21

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
