### PR TITLE
CI: Publish VS Code extension to OpenVSX Registry

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,6 +23,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ./package-lock.json
       - run: npm ci
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@dfe4f6ad46624424fe24cb5bca79839183399045 # 1.4.0
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@dfe4f6ad46624424fe24cb5bca79839183399045 # 1.4.0
         with:


### PR DESCRIPTION
## Description

This will make the extension more discoverable and more easily accessible to users.

Currently, This VS Code extension is only available at Microsoft's [Visual Studio Marketplace](https://marketplace.visualstudio.com/vscode). But, the proposed change would be super helpful, if we can release it to Eclipse Foundation's [Open VSX Registry](https://open-vsx.org/). This would help products like Gitpod, IDX, VSCodium, etc. to use this VS Code extension directly.

### ℹ️ Actions Items required from Admins

* [x]  [Create an access token](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#3-create-an-access-token)
* [x]  [Login and sign the Publisher Agreement](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#2-log-in-and-sign-the-publisher-agreement)
    * [x]  [Create an Eclipse account](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#1-create-an-eclipse-account)
    * [x]  [Create a namespace/publisher](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions#4-create-the-namespace).
* [x]  [Add access token to GitHub repository's Secrets.](https://github.com/openfga/vscode-ext/settings/secrets/actions/new) Name it **`OPEN_VSX_TOKEN`**.

### References
Closes #57 

