### PR TITLE
fix: document selector not working in github.dev

### DIFF
--- a/client/src/extension.browser.ts
+++ b/client/src/extension.browser.ts
@@ -9,11 +9,8 @@ let client: LanguageClient;
 // this method is called when vs code is activated
 export function activate(context: ExtensionContext) {
 
-	/*
-	 * all except the code to create the language client in not browser specific
-	 * and could be shared with a regular (Node) extension
-	 */
-	const documentSelector = [{ scheme: 'file', language: 'openfga' }, { scheme: 'untitled', language: 'openfga'}];
+	// Register the server for all document types
+	const documentSelector = [{ language: 'openfga' }];
 
 	// Options to control the language client
 	const clientOptions: LanguageClientOptions = {

--- a/client/src/extension.node.ts
+++ b/client/src/extension.node.ts
@@ -22,8 +22,8 @@ export function activate(context: ExtensionContext) {
 
 	// Options to control the language client
 	const clientOptions: LanguageClientOptions = {
-		// Register the server for plain text documents
-		documentSelector: [{ scheme: 'file', language: 'openfga' }, { scheme: 'untitled', language: 'openfga'}],
+		// Register the server for all document types
+		documentSelector: [{ language: 'openfga' }],
 		synchronize: {
 			// Notify the server about file changes to '.clientrc files contained in the workspace
 			fileEvents: workspace.createFileSystemWatcher('**/.clientrc')


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Removed restriction on what schemes to support for OpenFGA document selector.

Tested on Dev Host, VSIX, and vscode.dev


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Development Host:
<img width="716" alt="image" src="https://github.com/openfga/vscode-ext/assets/1425457/d014df3a-b02a-44dc-a9b5-bac09726d0a3">

VSIX install:
<img width="716" alt="image" src="https://github.com/openfga/vscode-ext/assets/1425457/6a9019f2-3b73-401b-8c71-6149ee718f9e">


vscode.dev - saved model:
<img width="875" alt="image" src="https://github.com/openfga/vscode-ext/assets/1425457/d91fd173-ff07-4ec9-9527-03c790005c6f">

vscode.dev - untitled model:
<img width="875" alt="image" src="https://github.com/openfga/vscode-ext/assets/1425457/a937e57f-beb0-4174-96d5-8428016f1878">


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
