### PR TITLE
fix: e2e tests working for node and web

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,8 +48,9 @@ jobs:
         cache: 'npm'
         cache-dependency-path: ./package-lock.json
     - run: npm install
+    - run: npx playwright install
     - run: npm run compile
-    - run: xvfb-run -a npm run test-node
+    - run: xvfb-run -a npm test
       if: runner.os == 'Linux'
-    - run: npm run test-node
+    - run: npm test
       if: runner.os != 'Linux'

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,8 +9,13 @@
 			"trace": true,
 			"runtimeExecutable": "${execPath}",
 			"sourceMaps": true,
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-			"outFiles": ["${workspaceRoot}/client/out/**/*.js", "${workspaceRoot}/server/out/**/*.js"],
+			"args": [
+				"--extensionDevelopmentPath=${workspaceRoot}"
+			],
+			"outFiles": [
+				"${workspaceRoot}/client/out/**/*.js",
+				"${workspaceRoot}/server/out/**/*.js"
+			],
 			"preLaunchTask": "npm: compile"
 		},
 		{
@@ -32,38 +37,52 @@
 				"--extensionTestsPath=${workspaceRoot}/client/out/test/index.node",
 				"${workspaceRoot}/client/testFixture"
 			],
+			"env": {
+				"VSCODE_TEST_NODE": "true"
+			},
 			"preLaunchTask": "npm: compile"
 		},
 		{
-      "name": "Run Web Extension in VS Code",
-      "type": "pwa-extensionHost",
-      "debugWebWorkerHost": true,
-      "request": "launch",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}",
-        "--extensionDevelopmentKind=web"
-      ],
-			"outFiles": ["${workspaceRoot}/client/out/**/*.js", "${workspaceRoot}/server/out/**/*.js"],
-      "preLaunchTask": "npm: watch"
-    },
+			"name": "Run Web Extension in VS Code",
+			"type": "pwa-extensionHost",
+			"debugWebWorkerHost": true,
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionDevelopmentKind=web"
+			],
+			"outFiles": [
+				"${workspaceRoot}/client/out/**/*.js",
+				"${workspaceRoot}/server/out/**/*.js"
+			],
+			"preLaunchTask": "npm: watch"
+		},
+		// TODO: fix failing web test:
+		// Currently file handler helper defaults to 'vscode-test-web' for browser based tests
+		// env var VSCODE_TEST_NODE sets the file handling to use 'file' for node tests
+		// While running the web test from launch, files are still using 'file' scheme instead of 'vscode-test-web'
+		// It also does not appear to take env vars when in this mode. 
 		{
-      "name": "Extension Tests in VS Code Web",
-      "type": "extensionHost",
-      "debugWebWorkerHost": true,
-      "request": "launch",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}",
-        "--extensionDevelopmentKind=web",
-        "--extensionTestsPath=${workspaceFolder}/client/out/test/index.browser",
+			"name": "Extension Tests in VS Code Web",
+			"type": "extensionHost",
+			"debugWebWorkerHost": true,
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionDevelopmentKind=web",
+				"--extensionTestsPath=${workspaceFolder}/client/out/test/index.browser",
 				"${workspaceRoot}/client/testFixture"
-      ],
-      "preLaunchTask": "npm: compile"
-    }
+			],
+			"preLaunchTask": "npm: compile"
+		}
 	],
 	"compounds": [
-        {
-            "name": "Client/Server",
-            "configurations": ["Launch Client", "Attach to Server"]
-        }
-    ]
+		{
+			"name": "Client/Server",
+			"configurations": [
+				"Launch Client",
+				"Attach to Server"
+			]
+		}
+	]
 }

--- a/client/src/test/extension.test.ts
+++ b/client/src/test/extension.test.ts
@@ -21,11 +21,10 @@ suite('Should execute command', () => {
 		const resultFromCommand = await commands.executeCommand<TextDocument>('openfga.commands.transformToJson');
 
 		// Get original document
-
-		const original = await workspace.fs.readFile(getDocUri('test.fga'));
+		const original = String.fromCharCode.apply(null, await workspace.fs.readFile(getDocUri('test.fga')));
 
 		// Call transform directly for comparison, using original doc
-		const resultFromMethodCall = JSON.stringify(transformer.transformDSLToJSON(original.toString()), null, "  ");
+		const resultFromMethodCall = JSON.stringify(transformer.transformDSLToJSON(original), null, "  ");
 
 		// Ensure result from command is the same as result from method.
 		assert.equal(editor.document.getText(), original);

--- a/client/src/test/helper.ts
+++ b/client/src/test/helper.ts
@@ -35,7 +35,11 @@ export const getDocPath = (p: string) => {
 	return path.resolve(__dirname, '../../testFixture', p);
 };
 export const getDocUri = (p: string) => {
-	return vscode.Uri.file(getDocPath(p));
+	if (process.env.VSCODE_TEST_NODE) {
+		return vscode.Uri.file(getDocPath(p));
+	} else {
+		return vscode.Uri.file(p).with({ scheme: 'vscode-test-web', authority: 'mount', path: `/${p}` });
+	}
 };
 
 export async function setTestContent(content: string): Promise<boolean> {

--- a/client/src/test/index.browser.ts
+++ b/client/src/test/index.browser.ts
@@ -7,6 +7,7 @@ export function run(): Promise<void> {
       ui: 'tdd',
       reporter: undefined
     });
+    mocha.timeout(30000);
 
     // bundles all files in the current directory matching `*.test`
     const importAll = (r: __WebpackModuleApi.RequireContext) => r.keys().forEach(r);

--- a/client/src/test/index.node.ts
+++ b/client/src/test/index.node.ts
@@ -12,7 +12,7 @@ export function run(): Promise<void> {
 		ui: 'tdd',
 		color: true
 	});
-	mocha.timeout(100000);
+	mocha.timeout(30000);
 
 	const testsRoot = __dirname;
 

--- a/package.json
+++ b/package.json
@@ -103,8 +103,10 @@
 		"compile": "webpack",
 		"watch": "webpack --watch",
 		"package": "webpack --mode production --devtool hidden-source-map",
-		"test-node": "sh ./scripts/e2e.sh",
+		"test-node": "sh ./scripts/e2e-node.sh",
 		"test-web": "vscode-test-web --browserType=chromium --extensionDevelopmentPath=. --extensionTestsPath=./client/out/test/index.browser.js ./client/testFixture",
+		"test-web-headless": "vscode-test-web --browserType=chromium --headless --extensionDevelopmentPath=. --extensionTestsPath=./client/out/test/index.browser.js ./client/testFixture",
+		"test": "npm run test-node && npm run test-web-headless",
 		"lint": "eslint ./client/src ./server/src --ext .ts,.tsx",
 		"postinstall": "cd client && npm install && cd ../server && npm install && cd .."
 	},

--- a/scripts/e2e-node.sh
+++ b/scripts/e2e-node.sh
@@ -3,4 +3,4 @@
 export CODE_TESTS_PATH="$(pwd)/client/out/test"
 export CODE_TESTS_WORKSPACE="$(pwd)/client/testFixture"
 
-node "$(pwd)/client/out/test/runTest"
+VSCODE_TEST_NODE="true" node "$(pwd)/client/out/test/runTest"


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

* Added env var `VSCODE_TEST_NODE` to dictate which file system structure to use whether in node or browser for the test suite. When set,`VSCODE_TEST_NODE` will use `file`, otherwise it uses `vscode-test-web` for browser.
* Changed github workflow to use `npm test` to run both node and web tests on a PR 

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
