### PR TITLE
fix: Lifting conditions grammar up to openfga

### DIFF
--- a/syntaxes/cel.injection.json
+++ b/syntaxes/cel.injection.json
@@ -8,22 +8,7 @@
   ],
   "repository": {
     "condition": {
-      "begin": "(condition)\\s([_a-zA-Z][_a-zA-Z0-9]+)\\((.*)\\)\\s*{",
-      "beginCaptures": {
-        "1": {
-          "name": "keyword.condition.openfga"
-        },
-        "2": {
-          "name": "entity.name.function.condition.openfga"
-        },
-        "3": {
-          "patterns": [
-            {
-              "include": "#cel-prama"
-            }
-          ]
-        }
-      },
+      "begin": "{",
       "end": "}",
       "patterns": [
         {
@@ -35,17 +20,6 @@
           ]
         }
       ]
-    },
-    "cel-prama": {
-      "match": "([_a-zA-Z][_a-zA-Z0-9]+)\\:\\s([_a-zA-Z][_a-zA-Z0-9]+),?",
-      "captures": {
-        "1": {
-          "name": "variable.parameter.name.condition.openfga"
-        },
-        "2": {
-          "name": "variable.parameter.type.condition.openfga"
-        }
-      }
     }
   }
 }

--- a/syntaxes/openfga.tmLanguage.json
+++ b/syntaxes/openfga.tmLanguage.json
@@ -14,9 +14,38 @@
     },
     {
       "include": "#symbols"
+    },
+    {
+      "include": "#condition"
     }
   ],
   "repository": {
+    "condition": {
+      "match": "(condition)\\s([_a-zA-Z][_a-zA-Z0-9]+)\\((.*)\\)\\s*",
+      "captures": {
+        "1": {
+          "name": "keyword.condition.openfga"
+        },
+        "2": {
+          "name": "entity.name.function.condition.openfga"
+        },
+        "3": {
+          "patterns": [
+            {
+              "match": "([_a-zA-Z][_a-zA-Z0-9]+)\\:\\s([_a-zA-Z][_a-zA-Z0-9]+),?",
+              "captures": {
+                "1": {
+                  "name": "variable.parameter.name.condition.openfga"
+                },
+                "2": {
+                  "name": "variable.parameter.type.condition.openfga"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
     "comments": {
       "patterns": [
         {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Highlighting CEL as [per this textMate grammar](https://github.com/hmarr/vscode-cel/blob/main/syntaxes/cel.tmLanguage.json)


This current grammar expects there only a single set of `{ }` parens for the condition expression. 

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
