### PR TITLE
fix: user & object formatter to allow '/' in ids

### DIFF
--- a/server/src/openfga-yaml-schema.ts
+++ b/server/src/openfga-yaml-schema.ts
@@ -124,6 +124,7 @@ const undefinedTypeTuple = (user: string, instancePath: string) => {
 
 // Format enforcement
 const identifier = "[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?";
+const id = "[a-zA-Z0-9/_-]+";
 
 const formatField = (field: string, regex: string, length: number) => {
   if (!field.match(new RegExp(regex) || field.length > length)) {
@@ -133,7 +134,7 @@ const formatField = (field: string, regex: string, length: number) => {
 };
 
 function formatUser(user: string): boolean {
-  return formatField(user, `^${identifier}:(\\*|${identifier}(#${identifier})?)$`, 512);
+  return formatField(user, `^${identifier}:(\\*|${id}(#${identifier})?)$`, 512);
 }
 
 function formatRelation(relation: string): boolean {
@@ -141,7 +142,7 @@ function formatRelation(relation: string): boolean {
 }
 
 function formatObject(object: string): boolean {
-  return formatField(object, `^${identifier}:${identifier}$`, 256);
+  return formatField(object, `^${identifier}:${id}$`, 256);
 }
 
 function formatCondition(condition: string): boolean {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Simplify formatter to allow for `ids` as unstructured strings.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

- fixes https://github.com/openfga/vscode-ext/issues/182

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
