### PR TITLE
chore: exclude eslint from dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,8 @@ updates:
       dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "eslint"
   - package-ecosystem: "npm"
     directory: "/server"
     schedule:
@@ -16,6 +18,8 @@ updates:
       dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "eslint"
   - package-ecosystem: "npm"
     directory: "/client"
     schedule:
@@ -24,6 +28,8 @@ updates:
       dependencies:
         patterns:
           - "*"
+        exclude-patterns:
+          - "eslint"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

eslint 9.x.x has breaking changes and incompatibilities with a lot of the ecosystem plugins

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

https://github.com/openfga/vscode-ext/pull/277

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
