### PR TITLE
fix: webpack sourcemap generation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,7 +44,7 @@
       "request": "launch",
       "args": ["--extensionDevelopmentPath=${workspaceFolder}", "--extensionDevelopmentKind=web"],
       "outFiles": ["${workspaceRoot}/client/out/**/*.js", "${workspaceRoot}/server/out/**/*.js"],
-      "preLaunchTask": "npm: watch"
+      "preLaunchTask": "npm: compile"
     },
     // TODO: fix failing web test:
     // Currently file handler helper defaults to 'vscode-test-web' for browser based tests
@@ -63,12 +63,6 @@
         "${workspaceRoot}/client/testFixture"
       ],
       "preLaunchTask": "npm: compile"
-    }
-  ],
-  "compounds": [
-    {
-      "name": "Client/Server",
-      "configurations": ["Launch Client", "Attach to Server"]
     }
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -131,8 +131,8 @@ const nodeServerConfig = {
   output: {
     filename: "[name].js",
     path: path.join(__dirname, "server", "out"),
-    libraryTarget: "var",
-    library: "serverExportVar",
+    libraryTarget: 'commonjs2',
+    devtoolModuleFilenameTemplate: '../[resource-path]'
   },
   resolve: {
     mainFields: ["module", "main"],
@@ -175,6 +175,7 @@ const browserServerConfig = {
     path: path.join(__dirname, "server", "out"),
     libraryTarget: "var",
     library: "serverExportVar",
+    devtoolModuleFilenameTemplate: '../[resource-path]'
   },
   resolve: {
     mainFields: ["module", "main"],


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Small fix for webpack to enable the ability to debug with sourcemaps.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
