### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/vscode-ext/security/code-scanning/1](https://github.com/openfga/vscode-ext/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to explicitly restrict the GITHUB_TOKEN permissions to the minimum required. Since neither the `lint` nor `build` jobs require write access to repository contents, the minimal permission of `contents: read` is sufficient. The best way to do this is to add the `permissions` block at the root level of the workflow (above `jobs:`), which will apply to all jobs unless overridden. No additional imports or definitions are needed; this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
