### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dryrun-publish.yaml
+++ b/.github/workflows/dryrun-publish.yaml
@@ -2,6 +2,8 @@ on:
   workflow_dispatch:
 
 name: Dryrun Publish Extension
+permissions:
+  contents: read
 jobs:
   test:
     uses: ./.github/workflows/main.yaml


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/vscode-ext/security/code-scanning/2](https://github.com/openfga/vscode-ext/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/dryrun-publish.yaml`. This block should be placed at the top level (applies to all jobs unless overridden), and should specify the minimum required permissions. Since the workflow appears to only need to read repository contents (for checkout and install), and does not push code or create issues/pull requests, the minimal permission is likely `contents: read`. If any job requires more, it can be overridden at the job level. The change should be made by inserting the following block after the `name:` field and before `jobs:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
