### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,8 @@ on:
 name: Publish Extension
 jobs:
   test:
+    permissions:
+      contents: read
     uses: ./.github/workflows/main.yaml
   publish:
     needs: test


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/vscode-ext/security/code-scanning/3](https://github.com/openfga/vscode-ext/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block to the `test` job in `.github/workflows/publish.yaml`. Since the job is named `test` and is likely only running tests (and not performing any write operations), the minimal required permissions are likely `contents: read`. This should be added directly under the `test:` job definition (i.e., at the same level as `uses:`). No other changes are needed, and this will not affect the existing functionality of the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
