### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dryrun-publish.yaml
+++ b/.github/workflows/dryrun-publish.yaml
@@ -2,6 +2,8 @@ on:
   workflow_dispatch:
 
 name: Dryrun Publish Extension
+permissions:
+  contents: read
 jobs:
   test:
     uses: ./.github/workflows/main.yaml


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/vscode-ext/security/code-scanning/4](https://github.com/openfga/vscode-ext/security/code-scanning/4)

To fix the problem, we should add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the root level of the workflow file, so it applies to all jobs that do not have their own `permissions` block. Based on the workflow's steps, the minimal required permission is likely `contents: read`, which allows jobs to read repository contents but not write to them. This change should be made at the top of the `.github/workflows/dryrun-publish.yaml` file, immediately after the `name:` field and before the `jobs:` field.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
