### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,8 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/vscode-ext/security/code-scanning/5](https://github.com/openfga/vscode-ext/security/code-scanning/5)

To fix the problem, we should add a `permissions` block to the `publish` job, specifying the minimal permissions required. Since the job appears to only need to read repository contents (for checkout and possibly for reading files), we should set `contents: read`. If, in the future, the job requires additional permissions (e.g., to create issues or pull requests), those can be added explicitly. The change should be made in `.github/workflows/publish.yaml`, by adding a `permissions` block under the `publish` job, above the `steps` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
