### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/vscode-ext/security/code-scanning/6](https://github.com/openfga/vscode-ext/security/code-scanning/6)

To fix the problem, you should add a `permissions` block to the workflow file. The best way to do this is to add the block at the top level of the workflow (just below the `on:` block and before `jobs:`), so that it applies to all jobs unless overridden. For the provided workflow, the jobs only need to read repository contents, so the minimal required permission is `contents: read`. No additional permissions are needed for the steps shown. You do not need to change any job steps or add any imports; simply add the `permissions` block to the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
