### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -6,6 +6,8 @@ on:
 jobs:
   semgrep:
     name: Scan
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/vscode-ext/security/code-scanning/7](https://github.com/openfga/vscode-ext/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly restrict the `GITHUB_TOKEN` permissions. Since the Semgrep job only needs to read repository contents, set `permissions: contents: read` at the job level (under `semgrep:`). This change should be made directly under the job definition (after `name: Scan` and before `runs-on:`) in `.github/workflows/semgrep.yaml`. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
