### PR TITLE
chore: ignore eslint 10.x dependabot updates until manual upgrade

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,9 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
+    ignore:
+      - dependency-name: "eslint"
+        versions: [">=10.0.0, <11.0.0"]
     groups:
       dependencies:
         patterns:
@@ -20,6 +23,9 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
+    ignore:
+      - dependency-name: "eslint"
+        versions: [">=10.0.0, <11.0.0"]
     groups:
       dependencies:
         patterns:
@@ -33,6 +39,9 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       prefix-development: "chore(deps-dev)"
+    ignore:
+      - dependency-name: "eslint"
+        versions: [">=10.0.0, <11.0.0"]
     groups:
       dependencies:
         patterns:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,7 @@ updates:
       prefix-development: "chore(deps-dev)"
     ignore:
       - dependency-name: "eslint"
-        versions: [">=10.0.0, <11.0.0"]
+        versions: [">=10.0.0 <11.0.0"]
     groups:
       dependencies:
         patterns:
@@ -25,7 +25,7 @@ updates:
       prefix-development: "chore(deps-dev)"
     ignore:
       - dependency-name: "eslint"
-        versions: [">=10.0.0, <11.0.0"]
+        versions: [">=10.0.0 <11.0.0"]
     groups:
       dependencies:
         patterns:
@@ -41,7 +41,7 @@ updates:
       prefix-development: "chore(deps-dev)"
     ignore:
       - dependency-name: "eslint"
-        versions: [">=10.0.0, <11.0.0"]
+        versions: [">=10.0.0 <11.0.0"]
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
The upgrade needs to be done manually