### PR TITLE
fix(ci): pin macOS runner to 15

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -35,7 +35,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-15, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Pins the macOS build job to `macos-15` instead of the moving `macos-latest` label.

## Why this is needed

GitHub recently moved `macos-latest` to macOS 26 on Apple Silicon. In that new environment, our existing VS Code Electron test launcher downloads VS Code but cannot find the expected `Electron` executable. The job then fails before any tests run.

This is not caused by the dependency changes in the currently failing Dependabot PRs. The same failure appears across unrelated PRs.

Using `macos-15` restores the previous compatible macOS environment, so we keep macOS test coverage while unblocking CI.

## Follow-up

We should upgrade `@vscode/test-electron` and validate the test suite explicitly on macOS 26 before moving the runner back to a newer image.

## Validation

- Parsed `.github/workflows/main.yaml` successfully with Ruby YAML.
- Ran `git diff --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)