### PR TITLE
fix(ci): upgrade VS Code test runner

### DIFF
--- a/.github/actions/upload-artifact/action.yaml
+++ b/.github/actions/upload-artifact/action.yaml
@@ -15,10 +15,11 @@ runs:
         scope: "@openfga"
         always-auth: false
         cache: "npm"
-        cache-dependency-path: ./package-lock.json
+        cache-dependency-path: |
+          package-lock.json
+          client/package-lock.json
+          server/package-lock.json
     - run: npm ci
-      shell: bash
-    - run: npm install @vscode/vsce
       shell: bash
     - run: npx vsce package -o openfga-latest.vsix
       shell: bash

--- a/.github/actions/upload-artifact/action.yaml
+++ b/.github/actions/upload-artifact/action.yaml
@@ -10,7 +10,7 @@ runs:
     - name: Install Node.js
       uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
       with:
-        node-version: 20.x
+        node-version: 22.x
         registry-url: "https://registry.npmjs.org"
         scope: "@openfga"
         always-auth: false

--- a/.github/workflows/dryrun-publish.yaml
+++ b/.github/workflows/dryrun-publish.yaml
@@ -23,7 +23,10 @@ jobs:
           scope: "@openfga"
           always-auth: false
           cache: "npm"
-          cache-dependency-path: ./package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            client/package-lock.json
+            server/package-lock.json
       - run: npm ci
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # 2.0.0

--- a/.github/workflows/dryrun-publish.yaml
+++ b/.github/workflows/dryrun-publish.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: "https://registry.npmjs.org"
           scope: "@openfga"
           always-auth: false

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,7 +25,10 @@ jobs:
           scope: "@openfga"
           always-auth: false
           cache: "npm"
-          cache-dependency-path: ./package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            client/package-lock.json
+            server/package-lock.json
       - run: npm install
       - run: npm run lint
       - run: npm audit
@@ -50,7 +53,10 @@ jobs:
           scope: "@openfga"
           always-auth: false
           cache: "npm"
-          cache-dependency-path: ./package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            client/package-lock.json
+            server/package-lock.json
       - run: npm install
       - run: npx playwright install
       - run: npm run compile

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: "https://registry.npmjs.org"
           scope: "@openfga"
           always-auth: false
@@ -45,7 +45,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: "https://registry.npmjs.org"
           scope: "@openfga"
           always-auth: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: "https://registry.npmjs.org"
           scope: "@openfga"
           always-auth: false
@@ -63,7 +63,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # 7.0.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: "https://registry.npmjs.org"
           scope: "@openfga"
           always-auth: false

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,7 +43,10 @@ jobs:
           scope: "@openfga"
           always-auth: false
           cache: "npm"
-          cache-dependency-path: ./package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            client/package-lock.json
+            server/package-lock.json
       - run: npm ci
       - name: Publish to Open VSX Registry
         uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # 2.0.0
@@ -68,7 +71,10 @@ jobs:
           scope: "@openfga"
           always-auth: false
           cache: "npm"
-          cache-dependency-path: ./package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            client/package-lock.json
+            server/package-lock.json
       - run: npm ci
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # 2.0.0

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "@vscode/test-electron": "^3.1.0"
       },
       "engines": {
+        "node": ">=22",
         "vscode": "^1.75.0"
       }
     },

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/vscode": "^1.120.0",
-        "@vscode/test-electron": "^2.5.2"
+        "@vscode/test-electron": "^3.1.0"
       },
       "engines": {
         "vscode": "^1.75.0"
@@ -67,9 +67,9 @@
       "license": "MIT"
     },
     "node_modules/@vscode/test-electron": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.5.2.tgz",
-      "integrity": "sha512-8ukpxv4wYe0iWMRQU18jhzJOHkeGKbnw7xWRX3Zw1WJA4cEKbHcmmLPdPrPtL6rhDcrlCZN+xKRpv09n4gRHYg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-3.1.0.tgz",
+      "integrity": "sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -80,7 +80,7 @@
         "semver": "^7.6.2"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=22"
       }
     },
     "node_modules/agent-base": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "url": "https://github.com/openfga/vscode-ext"
   },
   "engines": {
+    "node": ">=22",
     "vscode": "^1.75.0"
   },
   "dependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -27,6 +27,6 @@
   },
   "devDependencies": {
     "@types/vscode": "^1.120.0",
-    "@vscode/test-electron": "^2.5.2"
+    "@vscode/test-electron": "^3.1.0"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrades `@vscode/test-electron` from 2.5.2 to 3.1.0.
- Updates CI, publishing workflows, and the reusable VSIX-upload action from Node 20 to Node 22—the minimum runtime required by the upgraded test runner.
- Makes the client's `node >=22` requirement explicit.
- Ensures npm caches account for the root, client, and server lockfiles.
- Removes the redundant, unpinned VSCE installation from the VSIX-upload action.

## Why this fixes CI

The macOS failure was not caused by Dependabot updates or the runner label. The test launcher downloaded VS Code successfully, then tried to run this obsolete path:

```text
Visual Studio Code.app/Contents/MacOS/Electron
```

Recent VS Code releases renamed that executable (for example, to `Code`) and removed the old `Electron` compatibility symlink. `@vscode/test-electron` 2.5.2 still assumes the old path, so tests fail before they start.

`@vscode/test-electron` 3.1.0 includes the upstream fix from [microsoft/vscode-test#350](https://github.com/microsoft/vscode-test/pull/350). It reads `CFBundleExecutable` from the downloaded app's `Info.plist`, while retaining a fallback for older bundles.

## Validation

- The initial macOS 26 / Apple Silicon CI run passed with the upgraded runner; both Node and web test suites passed.
- Parsed all changed workflow and composite-action YAML files.
- Ran `git diff --check`.
- Installed the client dependency set with Node 22.
- Ran `npm run compile` successfully (existing webpack warnings only).
- Ran `npm run lint` successfully (existing five `no-explicit-any` warnings only).
- Verified VSIX packaging using the lockfile-pinned `@vscode/vsce`; no additional install is required.
- The latest CI run validates the review follow-ups and is in progress.

## Related

- [#581](https://github.com/openfga/vscode-ext/pull/581) was closed because pinning `macos-15` reproduced the same failure and did not address the root cause.
- Upstream fix: [microsoft/vscode-test#350](https://github.com/microsoft/vscode-test/pull/350)

🤖 Generated with [Claude Code](https://claude.com/claude-code)