### PR TITLE
chore(deps): support vscode-languageserver v10 package exports

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "@openfga/sdk": "^0.9.6",
         "@openfga/syntax-transformer": "^0.2.2",
         "ajv": "^8.20.0",
-        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver": "^10.1.0",
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-uri": "^3.1.0",
         "yaml": "^2.9.0"
@@ -429,34 +429,34 @@
       "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageserver": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-10.1.0.tgz",
+      "integrity": "sha512-9gEWpXkYGXoqG7pBnE8O8hx/yP7+Aabn4+peQ3KDicQv6qunHSWyLTud3OF0w4S2+HfDD+5HqYKiXQW9HAU6mA==",
       "license": "MIT",
       "dependencies": {
-        "vscode-languageserver-protocol": "3.17.5"
+        "vscode-languageserver-protocol": "3.18.2"
       },
       "bin": {
         "installServerIntoExtension": "bin/installServerIntoExtension"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
       }
     },
     "node_modules/vscode-languageserver-textdocument": {
@@ -466,9 +466,9 @@
       "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
       "license": "MIT"
     },
     "node_modules/vscode-uri": {

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "@openfga/sdk": "^0.9.6",
     "@openfga/syntax-transformer": "^0.2.2",
     "ajv": "^8.20.0",
-    "vscode-languageserver": "^9.0.1",
+    "vscode-languageserver": "^10.1.0",
     "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-uri": "^3.1.0",
     "yaml": "^2.9.0"

--- a/server/src/yaml-utils.ts
+++ b/server/src/yaml-utils.ts
@@ -1,8 +1,7 @@
 import { Range, Position, Diagnostic, DiagnosticSeverity } from "vscode-languageserver";
 
 import { Document, LineCounter, Node, Range as TokenRange, isMap, isPair, isScalar, isSeq } from "yaml";
-import { LinePos } from "yaml/dist/errors";
-import { BlockMap, SourceToken } from "yaml/dist/parse/cst";
+import type { CST } from "yaml";
 import { ErrorObject, ValidateFunction } from "ajv";
 import { transformer, validator } from "@openfga/syntax-transformer";
 import { TextDocument } from "vscode-languageserver-textdocument";
@@ -15,6 +14,8 @@ export type YamlStoreValidateResults = {
 };
 
 export type YamlFileFIeldContents = { contents: string; contentsUri: string; diagnostic?: Diagnostic };
+
+type LinePos = ReturnType<LineCounter["linePos"]>;
 
 export function isStringValue(str: unknown) {
   return typeof str == "string" || str instanceof String;
@@ -39,8 +40,8 @@ export function getFieldPosition(
   let position: { line: number; col: number } = { line: 0, col: 0 };
 
   // Get the model token and find its position
-  (yamlDoc.contents?.srcToken as BlockMap).items.forEach((i) => {
-    if (i.key?.offset !== undefined && (i.key as SourceToken).source === field) {
+  (yamlDoc.contents?.srcToken as CST.BlockMap).items.forEach((i) => {
+    if (i.key?.offset !== undefined && (i.key as CST.SourceToken).source === field) {
       position = lineCounter.linePos(i.key?.offset);
     }
   });

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "es2020",
     "lib": ["es2020", "WebWorker"],
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "sourceMap": true,
     "strict": true,
     "outDir": "out",


### PR DESCRIPTION
## Summary

- update `vscode-languageserver` from 9.0.1 to 10.1.0
- use TypeScript's package-exports-aware bundler resolution for the language server
- replace private YAML package imports with its public `CST` API

## Context

The dependency update in #571 exposes its entry points through package `exports`, which the server's legacy TypeScript module resolution cannot resolve. This PR includes that upgrade together with the compatibility changes needed to fix the `TS2307` CI failures.

## Testing

- `npm run compile`
- `npm run lint` (passes with 5 pre-existing warnings)
- `xvfb-run -a npm test` (6 Node tests and 6 browser tests pass)